### PR TITLE
amp_var_est OOT block added

### DIFF
--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -24,5 +24,6 @@ install(FILES
     cdma_packet_headerparser_b2_default.xml
     cdma_flag_gen.xml
     cdma_kronecker_filter.xml
-    cdma_freq_timing_estimator.xml DESTINATION share/gnuradio/grc/blocks
+    cdma_freq_timing_estimator.xml
+    cdma_amp_var_est.xml DESTINATION share/gnuradio/grc/blocks
 )

--- a/grc/cdma_amp_var_est.xml
+++ b/grc/cdma_amp_var_est.xml
@@ -1,0 +1,25 @@
+<block>
+  <name>amp_var_est</name>
+  <key>cdma_amp_var_est</key>
+  <category>cdma</category>
+  <import>import cdma</import>
+  <make>cdma.amp_var_est($alpha)</make>
+	<callback>set_alpha($alpha)</callback>
+  <param>
+    <name>alpha</name>
+    <key>alpha</key>
+    <type>float</type>
+  </param>
+  <sink>
+    <name>in</name>
+    <type>complex</type>
+  </sink>
+  <source>
+    <name>amp2</name>
+    <type>float</type>
+  </source>
+  <source>
+    <name>noise var</name>
+    <type>float</type>
+  </source>
+</block>

--- a/include/cdma/CMakeLists.txt
+++ b/include/cdma/CMakeLists.txt
@@ -26,5 +26,6 @@ install(FILES
     vector_insert2.h
     packet_header2.h
     packet_headerparser_b2.h
-    flag_gen.h DESTINATION include/cdma
+    flag_gen.h
+    amp_var_est.h DESTINATION include/cdma
 )

--- a/include/cdma/amp_var_est.h
+++ b/include/cdma/amp_var_est.h
@@ -1,0 +1,62 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2016 <+YOU OR YOUR COMPANY+>.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+
+#ifndef INCLUDED_CDMA_AMP_VAR_EST_H
+#define INCLUDED_CDMA_AMP_VAR_EST_H
+
+#include <cdma/api.h>
+#include <gnuradio/sync_block.h>
+
+namespace gr {
+  namespace cdma {
+
+    /*!
+     * \brief <+description of block+>
+     * \ingroup cdma
+     *
+     */
+    class CDMA_API amp_var_est : virtual public gr::sync_block
+    {
+     public:
+      typedef boost::shared_ptr<amp_var_est> sptr;
+
+      /*!
+       * \brief Return a shared_ptr to a new instance of cdma::amp_var_est.
+       *
+       * To avoid accidental use of raw pointers, cdma::amp_var_est's
+       * constructor is in a private implementation
+       * class. cdma::amp_var_est::make is the public interface for
+       * creating new instances.
+       */
+//-------------------------CODE HERE------------------------------
+      static sptr make(float alpha);
+			
+      virtual float alpha() const = 0;
+
+      virtual void set_alpha(float k) = 0;
+//----------------------------------------------------------------
+    };
+
+  } // namespace cdma
+} // namespace gr
+
+#endif /* INCLUDED_CDMA_AMP_VAR_EST_H */
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -29,7 +29,8 @@ list(APPEND cdma_sources
     packet_headerparser_b2_impl.cc
     chopper_impl.cc
     vector_insert2_impl.cc
-    flag_gen_impl.cc )
+    flag_gen_impl.cc
+    amp_var_est_impl.cc )
 
 add_library(gnuradio-cdma SHARED ${cdma_sources})
 target_link_libraries(gnuradio-cdma ${Boost_LIBRARIES} ${GNURADIO_ALL_LIBRARIES})

--- a/lib/amp_var_est_impl.cc
+++ b/lib/amp_var_est_impl.cc
@@ -1,0 +1,117 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2016 <+YOU OR YOUR COMPANY+>.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include "amp_var_est_impl.h"
+//-------------------------CODE HERE------------------------------
+//#include <volk/volk.h>
+//#include <gnuradio/filter/iir_filter.h>
+//#include <gnuradio/filter/api.h>
+#include <gnuradio/gr_complex.h>
+//----------------------------------------------------------------
+
+namespace gr {
+  namespace cdma {
+
+    amp_var_est::sptr
+    amp_var_est::make(float alpha)
+    {
+      return gnuradio::get_initial_sptr
+        (new amp_var_est_impl(alpha));
+    }
+
+    /*
+     * The private constructor
+     */
+//-------------------------CODE HERE------------------------------
+    amp_var_est_impl::amp_var_est_impl(float alpha)
+      : gr::sync_block("amp_var_est",
+              gr::io_signature::make(1, 1, sizeof(gr_complex)),
+              gr::io_signature::make2(2, 2, sizeof(float),sizeof(float)))
+    {
+			d_alpha = alpha;
+			pre0 = 0;
+			pre1 = 0;
+		}
+//----------------------------------------------------------------
+    /*
+     * Our virtual destructor.
+     */
+    amp_var_est_impl::~amp_var_est_impl()
+    {
+    }
+
+    int
+    amp_var_est_impl::work(int noutput_items,
+        gr_vector_const_void_star &input_items,
+        gr_vector_void_star &output_items)
+    {
+//-------------------------CODE HERE------------------------------
+      const gr_complex *in = (const gr_complex *) input_items[0];
+      float *out0 = (float *) output_items[0];//signal amplitude
+      float *out1 = (float *) output_items[1];//noise vaiance
+			int no = noutput_items;
+
+      // Do <+signal processing+>
+
+			for(int k=0;k<no;k++) {
+        float x=in[k].real(); // check this
+			  float tmp=x*x;
+			  pre0 = d_alpha*tmp + (1-d_alpha)*pre0;
+
+        pre1=d_alpha*x + (1-d_alpha)*pre1;
+			  tmp = pre1*pre1;
+
+			  out0[k] = pre0 - tmp;
+			  out1[k] = tmp;
+			}
+
+      // Tell runtime system how many output items we produced.
+      return noutput_items;
+//----------------------------------------------------------------
+    }
+
+		void
+		amp_var_est_impl::setup_rpc()
+		{
+			#ifdef GR_CTRLPORT
+      add_rpc_variable(
+				rpcbasic_sptr(new rpcbasic_register_get<amp_var_est, float>(
+		alias(), "alpha",
+	  &amp_var_est::alpha,
+	  pmt::mp(0.0f), pmt::mp(1.0f), pmt::mp(0.0f),
+	  "", "Get value of alpha", RPC_PRIVLVL_MIN, DISPTIME | DISPOPTSTRIP)));
+
+      add_rpc_variable(
+        rpcbasic_sptr(new rpcbasic_register_set<amp_var_est, float>(
+	  alias(), "alpha",
+	  &amp_var_est::set_alpha,
+	  pmt::mp(0.0f), pmt::mp(1.0f), pmt::mp(0.0f),
+	  "", "Set value of alpha", RPC_PRIVLVL_MIN, DISPNULL)));
+		#endif /* GR_CTRLPORT */
+		}
+
+  } /* namespace cdma */
+} /* namespace gr */
+

--- a/lib/amp_var_est_impl.cc
+++ b/lib/amp_var_est_impl.cc
@@ -76,15 +76,15 @@ namespace gr {
       // Do <+signal processing+>
 
 			for(int k=0;k<no;k++) {
-        float x=in[k].real(); // check this
+        float x=in[k].real();
 			  float tmp=x*x;
 			  pre0 = d_alpha*tmp + (1-d_alpha)*pre0;
 
         pre1=d_alpha*x + (1-d_alpha)*pre1;
 			  tmp = pre1*pre1;
 
-			  out0[k] = pre0 - tmp;
-			  out1[k] = tmp;
+				out0[k] = tmp;
+			  out1[k] = pre0 - tmp;
 			}
 
       // Tell runtime system how many output items we produced.

--- a/lib/amp_var_est_impl.h
+++ b/lib/amp_var_est_impl.h
@@ -1,0 +1,58 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2016 <+YOU OR YOUR COMPANY+>.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_CDMA_AMP_VAR_EST_IMPL_H
+#define INCLUDED_CDMA_AMP_VAR_EST_IMPL_H
+
+#include <cdma/amp_var_est.h>
+
+namespace gr {
+  namespace cdma {
+
+    class amp_var_est_impl : public amp_var_est
+    {
+     private:
+//-------------------------CODE HERE------------------------------
+			float d_alpha;
+			float pre0;//previous output of filter 0
+			float pre1;//previous output of filter 1
+//----------------------------------------------------------------
+
+     public:
+//-------------------------CODE HERE------------------------------
+			float alpha() const { return d_alpha; }
+			void set_alpha(float alpha) {d_alpha = alpha;}
+			void setup_rpc();
+
+      amp_var_est_impl(float alpha);
+//----------------------------------------------------------------
+      ~amp_var_est_impl();
+
+      // Where all the action really happens
+      int work(int noutput_items,
+         gr_vector_const_void_star &input_items,
+         gr_vector_void_star &output_items);
+    };
+
+  } // namespace cdma
+} // namespace gr
+
+#endif /* INCLUDED_CDMA_AMP_VAR_EST_IMPL_H */
+

--- a/swig/cdma_swig.i
+++ b/swig/cdma_swig.i
@@ -14,6 +14,7 @@
 #include "cdma/packet_header2.h"
 #include "cdma/packet_headerparser_b2.h"
 #include "gnuradio/digital/packet_header_default.h"
+#include "cdma/amp_var_est.h"
 
 %}
 %include "gnuradio/digital/packet_header_default.h"
@@ -34,3 +35,5 @@ GR_SWIG_BLOCK_MAGIC2(cdma, flag_gen);
 
 // Properly package up non-block objects
 %include "packet_header.i"
+%include "cdma/amp_var_est.h"
+GR_SWIG_BLOCK_MAGIC2(cdma, amp_var_est);


### PR DESCRIPTION
In the previous commit, I made a mistake that I assigned amp2 to out[1] and no_var to out[0] in the work function, and I forgot to compile cdma_rx_hier before testing. I've fixed that and the block should work well now.