### PR TITLE
Packet Error Calculator added

### DIFF
--- a/grc/CMakeLists.txt
+++ b/grc/CMakeLists.txt
@@ -26,5 +26,6 @@ install(FILES
     cdma_kronecker_filter.xml
     cdma_freq_timing_estimator.xml
     cdma_amp_var_est.xml
-    cdma_switched_peak_detector_fb.xml DESTINATION share/gnuradio/grc/blocks
+    cdma_switched_peak_detector_fb.xml
+    cdma_pac_err_cal.xml DESTINATION share/gnuradio/grc/blocks
 )

--- a/grc/cdma_pac_err_cal.xml
+++ b/grc/cdma_pac_err_cal.xml
@@ -1,0 +1,54 @@
+<block>
+  <name>Packet Error Calculator</name>
+  <key>cdma_pac_err_cal</key>
+  <category>cdma</category>
+  <import>import cdma</import>
+  <make>cdma.pac_err_cal($winsize, $cycsize, $pkt_num_tag)</make>
+  <callback>set_winsize($winsize)</callback>
+  <callback>set_cycsize($cycsize)</callback>
+  <callback>set_pkt_num_tag($pkt_num_tag)</callback>
+
+  <param>
+    <name>packet number tag</name>
+    <key>pkt_num_tag</key>
+    <type>string</type>
+  </param>
+  <param>
+    <name>window size</name>
+    <key>winsize</key>
+    <type>int</type>
+  </param>
+  <param>
+    <name>cycle size</name>
+    <key>cycsize</key>
+    <type>int</type>
+  </param>
+
+  <sink>
+    <name>print</name>
+    <type>message</type>
+    <optional>1</optional>
+  </sink>
+  <sink>
+    <name>errCal</name>
+    <type>message</type>
+    <optional>1</optional>
+  </sink>
+
+  <doc>
+    This is a message debug block with no outputs and two message-type inputs, corresponding to two event-driven functions (ie. being called when message arrives at the port). There are three parameters only used by the second function: 
+
+    pkt_num_tag: the tag name for the packet index, ie. the "key" part in the dictionary pair (key, value) when extracting packet index. Eg.: cp.num_tag_name
+    winsize: the length of the observation window, to be set manually. Eg.: 1024
+    cycsize: the maximum index number + 1, to be determined by the header size. (eg. cycsize = 2^n if the head is of n bits). Eg.: 4096
+
+    1) First function: print()
+    Print out the message arriving at this port. 
+    Method: Use pmt::print().
+
+    2) Second function: errCal()
+    Calculate the packet error rate for a certain observation window.
+    Method: Use pmt::dict_ref() to extract the packet index number. In a certain window for every such index number, count and cumulate the number of packet errors and the number of packets sent. At the end of each window, take the ratio of these two values, displayed as E-Rate.
+
+  </doc>
+</block>

--- a/include/cdma/CMakeLists.txt
+++ b/include/cdma/CMakeLists.txt
@@ -28,5 +28,6 @@ install(FILES
     packet_headerparser_b2.h
     flag_gen.h
     amp_var_est.h
-    switched_peak_detector_fb.h DESTINATION include/cdma
+    switched_peak_detector_fb.h
+    pac_err_cal.h DESTINATION include/cdma
 )

--- a/include/cdma/pac_err_cal.h
+++ b/include/cdma/pac_err_cal.h
@@ -1,0 +1,61 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2016 <+YOU OR YOUR COMPANY+>.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+
+#ifndef INCLUDED_CDMA_PAC_ERR_CAL_H
+#define INCLUDED_CDMA_PAC_ERR_CAL_H
+
+#include <cdma/api.h>
+#include <gnuradio/block.h>
+
+namespace gr {
+  namespace cdma {
+
+    /*!
+     * \brief <+description of block+>
+     * \ingroup cdma
+     *
+     */
+    class CDMA_API pac_err_cal : virtual public gr::block
+    {
+     public:
+      typedef boost::shared_ptr<pac_err_cal> sptr;
+
+      /*!
+       * \brief Return a shared_ptr to a new instance of cdma::pac_err_cal.
+       *
+       * To avoid accidental use of raw pointers, cdma::pac_err_cal's
+       * constructor is in a private implementation
+       * class. cdma::pac_err_cal::make is the public interface for
+       * creating new instances.
+       */
+      static sptr make(unsigned long winsize, unsigned long cycsize, std::string pkt_num_tag);
+
+      virtual void set_winsize(unsigned long k) = 0;
+      virtual void set_cycsize(unsigned long t) = 0;
+      virtual void set_pkt_num_tag(std::string str) = 0;
+
+    };
+
+  } // namespace cdma
+} // namespace gr
+
+#endif /* INCLUDED_CDMA_PAC_ERR_CAL_H */
+

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -31,7 +31,8 @@ list(APPEND cdma_sources
     vector_insert2_impl.cc
     flag_gen_impl.cc
     amp_var_est_impl.cc
-    switched_peak_detector_fb_impl.cc )
+    switched_peak_detector_fb_impl.cc
+    pac_err_cal_impl.cc )
 
 add_library(gnuradio-cdma SHARED ${cdma_sources})
 target_link_libraries(gnuradio-cdma ${Boost_LIBRARIES} ${GNURADIO_ALL_LIBRARIES})

--- a/lib/pac_err_cal_impl.cc
+++ b/lib/pac_err_cal_impl.cc
@@ -1,0 +1,144 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2016 <+YOU OR YOUR COMPANY+>.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <gnuradio/io_signature.h>
+#include "pac_err_cal_impl.h"
+#include <cstdio>
+#include <iostream>
+//#include <stdio>
+
+
+namespace gr {
+  namespace cdma {
+
+    pac_err_cal::sptr
+    pac_err_cal::make(unsigned long winsize, unsigned long cycsize, std::string pkt_num_tag)
+    {
+      return gnuradio::get_initial_sptr
+        (new pac_err_cal_impl(winsize, cycsize, pkt_num_tag));
+    }
+
+    /*
+     * The private constructor
+     */
+    pac_err_cal_impl::pac_err_cal_impl(unsigned long winsize, unsigned long cycsize, std::string pkt_num_tag)
+      : gr::block("pac_err_cal",
+              gr::io_signature::make(0, 0, 0),
+              gr::io_signature::make(0, 0, 0))
+    {
+      d_pkt_num_tag = pkt_num_tag;
+      d_winsize = winsize;
+      d_cycsize = cycsize;
+      d_count_errs = 0;
+      d_count_pktsent = 0;
+      d_curnum = 0;
+
+      d_first = 0;
+      d_prev = 0;
+      d_erate = 0;
+
+      message_port_register_in(pmt::mp("print"));
+      set_msg_handler(pmt::mp("print"), boost::bind(&pac_err_cal_impl::print, this, _1));
+
+      message_port_register_in(pmt::mp("errCal"));
+      set_msg_handler(pmt::mp("errCal"), boost::bind(&pac_err_cal_impl::errCal, this, _1));
+    }
+
+    /*
+     * Our virtual destructor.
+     */
+    pac_err_cal_impl::~pac_err_cal_impl()
+    {
+    }
+
+
+    void
+    pac_err_cal_impl::print(pmt::pmt_t msg)
+    {
+      std::cout << "******* MESSAGE DEBUG PRINT ********\n";
+      pmt::print(msg);
+      std::cout << "************************************\n";
+    }
+
+    void
+    pac_err_cal_impl::errCal(pmt::pmt_t msg)
+    {
+      
+      //pmt::pmt_t key0 = pmt::intern("cdma_packet_num");
+      pmt::pmt_t key0 = pmt::intern(d_pkt_num_tag);
+      if (pmt::dict_has_key (msg, key0))
+      {
+
+        pmt::pmt_t not_found;
+        pmt::pmt_t val0 = pmt::dict_ref(msg,key0,not_found);
+        unsigned long val = pmt::to_uint64(val0);
+
+        //std::cout << "val: " << val << "\n";
+        if (val < 0 || val >= d_cycsize)
+        {
+          //std::cout << "invalid index number\n";
+          return;
+        }
+
+        d_curnum = d_curnum + 1; // # of packets stocked in the current window + 1
+
+        //increment errs and packets sent
+        if (val < d_prev) // a new cycle starts while the window hasn't been filled up
+        { 
+          //std::cout << "val: " << val << "\n";
+          //std::cout << "prev: " << d_prev << "\n";
+          //std::cout << "new cycle\n\n";
+          d_count_errs = d_count_errs + d_cycsize + val - d_prev - 1;
+          d_count_pktsent = d_count_pktsent + d_cycsize + val - d_prev;
+
+        }
+        else
+        {
+          d_count_errs = d_count_errs + val - d_prev - 1;
+          d_count_pktsent = d_count_pktsent + val - d_prev;
+        }
+
+        //terminate the window
+        if (d_curnum >= d_winsize)
+        {
+          d_erate = (float) d_count_errs / d_count_pktsent; // key calculation
+          
+          //std::cout << "E-RATE: " << d_erate << "\t\t E-#: " << d_count_errs << "\t\t TAIL: " << val << "\t\t HEAD: " << d_first << "\n";          
+          std::cout << "E-RATE: " << d_erate << "\n";
+          d_curnum = 0;
+          d_count_errs = 0;
+          d_count_pktsent = 0;
+        }
+        else if (d_curnum == 1)
+        {
+          d_first = val;
+        }
+
+        d_prev = val;     
+      }
+    }
+
+  } /* namespace cdma */
+} /* namespace gr */
+

--- a/lib/pac_err_cal_impl.h
+++ b/lib/pac_err_cal_impl.h
@@ -1,0 +1,62 @@
+/* -*- c++ -*- */
+/* 
+ * Copyright 2016 <+YOU OR YOUR COMPANY+>.
+ * 
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3, or (at your option)
+ * any later version.
+ * 
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this software; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef INCLUDED_CDMA_PAC_ERR_CAL_IMPL_H
+#define INCLUDED_CDMA_PAC_ERR_CAL_IMPL_H
+
+#include <cdma/pac_err_cal.h>
+#include <gnuradio/block.h>
+#include <gnuradio/thread/thread.h>
+#include <pmt/pmt.h>
+
+namespace gr {
+  namespace cdma {
+
+    class pac_err_cal_impl : public pac_err_cal
+    {
+     private:
+      unsigned long d_winsize;        // size of the block window
+      unsigned long d_cycsize;        // size of a complete cycle, say 4096
+
+      unsigned long d_first;          // index of the first received packet in the current window
+      unsigned long d_count_pktsent;  // number of packets sent from the tx
+      unsigned long d_count_errs;     // number of error packets in the current window
+      unsigned long d_curnum;         // number of packets received in the current window
+      unsigned long d_prev;           // the index of the last packet in service
+      float d_erate;                  // error rate result
+      std::string d_pkt_num_tag;      // tag name for the packet index
+
+      void print(pmt::pmt_t msg);
+      void errCal(pmt::pmt_t msg);
+
+     public:
+      pac_err_cal_impl(unsigned long winsize, unsigned long cycsize, std::string pkt_num_tag);
+      ~pac_err_cal_impl();
+
+      void set_winsize(unsigned long winsize) {d_winsize = winsize;}
+      void set_cycsize(unsigned long cycsize) {d_cycsize = cycsize;}
+      void set_pkt_num_tag(std::string pkt_num_tag) {d_pkt_num_tag = pkt_num_tag;}
+    };
+
+  } // namespace cdma
+} // namespace gr
+
+#endif /* INCLUDED_CDMA_PAC_ERR_CAL_IMPL_H */
+

--- a/swig/cdma_swig.i
+++ b/swig/cdma_swig.i
@@ -16,6 +16,7 @@
 #include "gnuradio/digital/packet_header_default.h"
 #include "cdma/amp_var_est.h"
 #include "cdma/switched_peak_detector_fb.h"
+#include "cdma/pac_err_cal.h"
 
 %}
 %include "gnuradio/digital/packet_header_default.h"
@@ -42,3 +43,5 @@ GR_SWIG_BLOCK_MAGIC2(cdma, switched_peak_detector_fb);
 
 // Properly package up non-block objects
 %include "packet_header.i"
+%include "cdma/pac_err_cal.h"
+GR_SWIG_BLOCK_MAGIC2(cdma, pac_err_cal);


### PR DESCRIPTION
1) All packet index related integer varibles / parameters changed into type **unsigned long**;
2) New parameter "packet number tag" added to cope with different packet tag names;
3) Documentation modified in the .xml file.