### PR TITLE
Solved the problem of Initialization Packet Index when changing Modulation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,12 @@ Note: this is your git directory prefix not the installation prefix!
 prefix="YOUR_PREFIX_HERE/gr-cdma"  # put the prefix of your gr-cdma trunk
 
 2) Build the package
-> mkdir build_cdma
 
-> cd build_cdma
+method one:
 
-> cmake -DENABLE_DOXYGEN=ON ../gr-cdma
+> cd build
+
+> cmake -DENABLE_DOXYGEN=ON ../
 
 > make
 
@@ -38,6 +39,15 @@ prefix="YOUR_PREFIX_HERE/gr-cdma"  # put the prefix of your gr-cdma trunk
 
 > sudo ldconfig
 
+method two
+
+> cd build
+
+> ./build.sh
+
+press "i" or "install" to compile and install
+
+press "u" or "uninstall" to uninstall 
 
 3) compile hierarchical blocks and play with built in apps
 > cd gr-cdma/apps

--- a/apps/cdma_rx_hier.grc
+++ b/apps/cdma_rx_hier.grc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<?grc format='1' created='3.7.10'?>
+<?grc format='1' created='3.7.9'?>
 <flow_graph>
   <timestamp>Fri Mar 14 16:40:04 2014</timestamp>
   <block>
@@ -1108,7 +1108,7 @@
     </param>
   </block>
   <block>
-    <key>cdma_packet_headerparser_b2_default</key>
+    <key>cdma_packet_headerparser_b2</key>
     <param>
       <key>alias</key>
       <value></value>
@@ -1124,6 +1124,49 @@
     <param>
       <key>_enabled</key>
       <value>True</value>
+    </param>
+    <param>
+      <key>header_formatter</key>
+      <value>cp.local_header_obj</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(608, 1643)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>cdma_packet_headerparser_b2_0</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+  </block>
+  <block>
+    <key>cdma_packet_headerparser_b2_default</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>0</value>
     </param>
     <param>
       <key>_coordinate</key>
@@ -1352,49 +1395,6 @@
     <param>
       <key>packed</key>
       <value>True</value>
-    </param>
-  </block>
-  <block>
-    <key>digital_packet_headerparser_b</key>
-    <param>
-      <key>alias</key>
-      <value></value>
-    </param>
-    <param>
-      <key>comment</key>
-      <value></value>
-    </param>
-    <param>
-      <key>affinity</key>
-      <value></value>
-    </param>
-    <param>
-      <key>_enabled</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>header_formatter</key>
-      <value>cp.header_formatter.formatter()</value>
-    </param>
-    <param>
-      <key>_coordinate</key>
-      <value>(627, 1599)</value>
-    </param>
-    <param>
-      <key>_rotation</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>id</key>
-      <value>digital_packet_headerparser_b_0</value>
-    </param>
-    <param>
-      <key>maxoutbuf</key>
-      <value>0</value>
-    </param>
-    <param>
-      <key>minoutbuf</key>
-      <value>0</value>
     </param>
   </block>
   <block>
@@ -2120,6 +2120,12 @@
     <sink_key>0</sink_key>
   </connection>
   <connection>
+    <source_block_id>cdma_packet_headerparser_b2_0</source_block_id>
+    <sink_block_id>zzz_pad_sink_0_1_0_1_0</sink_block_id>
+    <source_key>header_data</source_key>
+    <sink_key>in</sink_key>
+  </connection>
+  <connection>
     <source_block_id>cdma_packet_headerparser_b2_default_0</source_block_id>
     <sink_block_id>zzz_pad_sink_0_1_0_1_0</sink_block_id>
     <source_key>header_data</source_key>
@@ -2145,13 +2151,13 @@
   </connection>
   <connection>
     <source_block_id>digital_constellation_decoder_cb_0_0</source_block_id>
-    <sink_block_id>cdma_packet_headerparser_b2_default_0</sink_block_id>
+    <sink_block_id>cdma_packet_headerparser_b2_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
   <connection>
     <source_block_id>digital_constellation_decoder_cb_0_0</source_block_id>
-    <sink_block_id>digital_packet_headerparser_b_0</sink_block_id>
+    <sink_block_id>cdma_packet_headerparser_b2_default_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>
@@ -2166,12 +2172,6 @@
     <sink_block_id>pad_sink_0_1_0_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
-  </connection>
-  <connection>
-    <source_block_id>digital_packet_headerparser_b_0</source_block_id>
-    <sink_block_id>zzz_pad_sink_0_1_0_1_0</sink_block_id>
-    <source_key>header_data</source_key>
-    <sink_key>in</sink_key>
   </connection>
   <connection>
     <source_block_id>interp_fir_filter_xxx_0_0</source_block_id>

--- a/apps/cdma_rx_hier1.grc
+++ b/apps/cdma_rx_hier1.grc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<?grc format='1' created='3.7.10'?>
+<?grc format='1' created='3.7.9'?>
 <flow_graph>
   <timestamp>Wed Oct  1 22:01:31 2014</timestamp>
   <block>
@@ -1108,6 +1108,49 @@
     </param>
   </block>
   <block>
+    <key>cdma_packet_headerparser_b2</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>header_formatter</key>
+      <value>cp.local_header_obj</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(600, 1547)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>cdma_packet_headerparser_b2_0</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+  </block>
+  <block>
     <key>cdma_packet_headerparser_b2_default</key>
     <param>
       <key>alias</key>
@@ -1123,11 +1166,11 @@
     </param>
     <param>
       <key>_enabled</key>
-      <value>1</value>
+      <value>0</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(560, 1477)</value>
+      <value>(584, 1475)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -2060,6 +2103,12 @@
     <sink_key>0</sink_key>
   </connection>
   <connection>
+    <source_block_id>cdma_packet_headerparser_b2_0</source_block_id>
+    <sink_block_id>zzz_pad_sink_0_1_0_1_0</sink_block_id>
+    <source_key>header_data</source_key>
+    <sink_key>in</sink_key>
+  </connection>
+  <connection>
     <source_block_id>cdma_packet_headerparser_b2_default_0</source_block_id>
     <sink_block_id>zzz_pad_sink_0_1_0_1_0</sink_block_id>
     <source_key>header_data</source_key>
@@ -2074,6 +2123,12 @@
   <connection>
     <source_block_id>chopper_correlator_0</source_block_id>
     <sink_block_id>RX_training_0_3_0_0_1</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>digital_constellation_decoder_cb_0_0</source_block_id>
+    <sink_block_id>cdma_packet_headerparser_b2_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>
   </connection>

--- a/apps/cdma_tx_hier.grc
+++ b/apps/cdma_tx_hier.grc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<?grc format='1' created='3.7.10'?>
+<?grc format='1' created='3.7.9'?>
 <flow_graph>
   <timestamp>Wed Feb 19 13:40:39 2014</timestamp>
   <block>
@@ -89,7 +89,7 @@
     </param>
     <param>
       <key>_enabled</key>
-      <value>1</value>
+      <value>0</value>
     </param>
     <param>
       <key>_coordinate</key>
@@ -878,7 +878,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(544, 131)</value>
+      <value>(544, 123)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -921,11 +921,11 @@
     </param>
     <param>
       <key>header_formatter</key>
-      <value>local_header_formatter.formatter()</value>
+      <value>cp.local_header_obj.formatter()</value>
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(552, 109)</value>
+      <value>(544, 59)</value>
     </param>
     <param>
       <key>_rotation</key>

--- a/apps/cdma_tx_hier1.grc
+++ b/apps/cdma_tx_hier1.grc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<?grc format='1' created='3.7.10'?>
+<?grc format='1' created='3.7.9'?>
 <flow_graph>
   <timestamp>Wed Oct  1 22:56:04 2014</timestamp>
   <block>
@@ -89,7 +89,7 @@
     </param>
     <param>
       <key>_enabled</key>
-      <value>1</value>
+      <value>0</value>
     </param>
     <param>
       <key>_coordinate</key>
@@ -106,6 +106,33 @@
     <param>
       <key>value</key>
       <value>cdma.packet_header2(cp.bits_per_header,cp.length_tag_name,cp.num_tag_name, cp.header_mod.bits_per_symbol(),tcm_type_selector, "tcm_type")</value>
+    </param>
+  </block>
+  <block>
+    <key>variable</key>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(1000, 19)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>test_point</value>
+    </param>
+    <param>
+      <key>value</key>
+      <value>cp.local_header_obj.set_tcm_type(tcm_type_selector)</value>
     </param>
   </block>
   <block>
@@ -855,7 +882,7 @@
     </param>
     <param>
       <key>_enabled</key>
-      <value>True</value>
+      <value>0</value>
     </param>
     <param>
       <key>header_formatter</key>
@@ -863,7 +890,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(664, 245)</value>
+      <value>(664, 235)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -872,6 +899,53 @@
     <param>
       <key>id</key>
       <value>digital_packet_headergenerator_bb_0</value>
+    </param>
+    <param>
+      <key>len_tag_key</key>
+      <value>cp.length_tag_name</value>
+    </param>
+    <param>
+      <key>maxoutbuf</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>minoutbuf</key>
+      <value>0</value>
+    </param>
+  </block>
+  <block>
+    <key>digital_packet_headergenerator_bb</key>
+    <param>
+      <key>alias</key>
+      <value></value>
+    </param>
+    <param>
+      <key>comment</key>
+      <value></value>
+    </param>
+    <param>
+      <key>affinity</key>
+      <value></value>
+    </param>
+    <param>
+      <key>_enabled</key>
+      <value>True</value>
+    </param>
+    <param>
+      <key>header_formatter</key>
+      <value>cp.local_header_obj.formatter()</value>
+    </param>
+    <param>
+      <key>_coordinate</key>
+      <value>(664, 307)</value>
+    </param>
+    <param>
+      <key>_rotation</key>
+      <value>0</value>
+    </param>
+    <param>
+      <key>id</key>
+      <value>digital_packet_headergenerator_bb_0_0</value>
     </param>
     <param>
       <key>len_tag_key</key>
@@ -898,7 +972,7 @@
     </param>
     <param>
       <key>_coordinate</key>
-      <value>(944, 252)</value>
+      <value>(976, 275)</value>
     </param>
     <param>
       <key>_rotation</key>
@@ -1525,6 +1599,12 @@
     <sink_key>0</sink_key>
   </connection>
   <connection>
+    <source_block_id>blocks_repack_bits_bb_1_0</source_block_id>
+    <sink_block_id>digital_packet_headergenerator_bb_0_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
     <source_block_id>blocks_stream_to_tagged_stream_0</source_block_id>
     <sink_block_id>header_bits_1_0_0</sink_block_id>
     <source_key>0</source_key>
@@ -1574,6 +1654,12 @@
   </connection>
   <connection>
     <source_block_id>digital_packet_headergenerator_bb_0</source_block_id>
+    <sink_block_id>header_bits_1_0</sink_block_id>
+    <source_key>0</source_key>
+    <sink_key>0</sink_key>
+  </connection>
+  <connection>
+    <source_block_id>digital_packet_headergenerator_bb_0_0</source_block_id>
     <sink_block_id>header_bits_1_0</sink_block_id>
     <source_key>0</source_key>
     <sink_key>0</sink_key>

--- a/apps/cdma_txrx.grc
+++ b/apps/cdma_txrx.grc
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<?grc format='1' created='3.7.10'?>
+<?grc format='1' created='3.7.9'?>
 <flow_graph>
   <timestamp>Fri Mar 14 16:56:42 2014</timestamp>
   <block>
@@ -1856,7 +1856,7 @@
     </param>
     <param>
       <key>cycsize</key>
-      <value>4096</value>
+      <value>2**cp.cdma_packet_num_bit</value>
     </param>
     <param>
       <key>pkt_num_tag</key>

--- a/build/build.sh
+++ b/build/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+echo "i/install for compiling and install"
+echo "u/uninstall for uninstall"
+read cmd
+if [ $cmd == "i" ] || [ $cmd == "install" ]; then
+	cmake -DENABLE_DOXYGEN=ON ../
+	make
+	sudo make install
+	sudo ldconfig
+elif [ $cmd == "u" ] || [ $cmd == "uninstall" ]; then
+	sudo make uninstall
+fi

--- a/python/cdma_parameters.py
+++ b/python/cdma_parameters.py
@@ -89,12 +89,18 @@ print "CDMA PARAMETERS : for adaptive coded modulation"
 
 prefix="/home/anastas/gr-cdma/"  # put the prefix of your gr-cdma trunk
 
+
 length_tag_name = "cdma_packet_len"
 num_tag_name = "cdma_packet_num"
 
 #==========================================
 # header info
-bits_per_header=12+16+8+4;  #4 bits indicating modulation and code mode.
+cdma_packet_len     = 12
+cdma_tcm            = 4
+cdma_packet_num_bit = 16
+cdma_crc_len        = 8
+bits_per_header     = cdma_packet_len + cdma_tcm + cdma_packet_num_bit + cdma_crc_len
+#bits_per_header=12+16+8+4;  #4 bits indicating modulation and code mode.
 header_mod = digital.constellation_bpsk();
 symbols_per_header = bits_per_header/header_mod.bits_per_symbol()
 if (1.0*bits_per_header)/header_mod.bits_per_symbol() != symbols_per_header:
@@ -168,6 +174,11 @@ redudant_bytes_percents = [(1.0*additional_bytes_per_frame[i])/(trellis_coded_pa
 #print "you have wasted ",redudant_bytes_percents," percent of bytes per payload for ", modulation_names, " respectively, with this symbols_per_frame setting.\n"
 #print "\n"
 
+
+#=========================================
+# packet header formatter
+tcm_type_selector_default = 0
+local_header_obj = cdma.packet_header2(bits_per_header,length_tag_name,num_tag_name, header_mod.bits_per_symbol(),tcm_type_selector_default, "tcm_type") 
 
 
 #==========================================


### PR DESCRIPTION
I did three modification
1. Solved the problem of Initialization Packet Index when changing Modulation method
All the code can be generated automatically. 
I first create the instance of  "packet_header2" in the cdma_parameter rather than in the tx or rx hierarchical block
Add a Variable block in cdma_tx_hier1.grc, the value of the block is "cp.local_header_obj.set_tcm_type(tcm_type_selector)" 
Because this command involves "tcm_type_selector", which is the modulation type, this command will be called when the button pressed.
2. Change the parameter for block "Packet Error Calculator"
The "cycle_size" will be computed with parameters set in "cdma_parameter.py" rather than being set manually.
3. Create a scrip file for un/installation
file is /build/build.sh and README.md is also modified
BTW, I think the command "cmake -DENABLE_DOXYGEN=ON ../gr-cdma" should be changed to "cmake -DENABLE_DOXYGEN=ON ../".  